### PR TITLE
正誤表とサンプルコードを更新

### DIFF
--- a/_chapter17/section68/entity/task.go
+++ b/_chapter17/section68/entity/task.go
@@ -2,11 +2,20 @@ package entity
 
 import "time"
 
+type TaskID int64
+type TaskStatus string
+
+const (
+	TaskStatusTodo  TaskStatus = "todo"
+	TaskStatusDoing TaskStatus = "doing"
+	TaskStatusDone  TaskStatus = "done"
+)
+
 type Task struct {
-	ID      int       `json:"id"`
-	Title   string    `json:"title"`
-	Status  string    `json:"status" `
-	Created time.Time `json:"created"`
+	ID      TaskID     `json:"id"`
+	Title   string     `json:"title"`
+	Status  TaskStatus `json:"status" `
+	Created time.Time  `json:"created"`
 }
 
 type Tasks []*Task

--- a/_chapter17/section68/handler/add_task.go
+++ b/_chapter17/section68/handler/add_task.go
@@ -48,6 +48,6 @@ func (at *AddTask) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	rsp := struct {
 		ID int `json:"id"`
-	}{ID: id}
+	}{ID: int(id)}
 	RespondJSON(ctx, w, rsp, http.StatusOK)
 }

--- a/_chapter17/section68/handler/add_task_test.go
+++ b/_chapter17/section68/handler/add_task_test.go
@@ -49,7 +49,7 @@ func TestAddTask(t *testing.T) {
 			)
 
 			sut := AddTask{Store: &store.TaskStore{
-				Tasks: map[int]*entity.Task{},
+				Tasks: map[entity.TaskID]*entity.Task{},
 			}, Validator: validator.New()}
 			sut.ServeHTTP(w, r)
 

--- a/_chapter17/section68/store/store.go
+++ b/_chapter17/section68/store/store.go
@@ -7,25 +7,25 @@ import (
 )
 
 var (
-	Tasks = &TaskStore{Tasks: map[int]*entity.Task{}}
+	Tasks = &TaskStore{Tasks: map[entity.TaskID]*entity.Task{}}
 
 	ErrNotFound = errors.New("not found")
 )
 
 type TaskStore struct {
 	// 動作確認用の仮実装なのであえてexportしている。
-	LastID int
-	Tasks  map[int]*entity.Task
+	LastID entity.TaskID
+	Tasks  map[entity.TaskID]*entity.Task
 }
 
-func (ts *TaskStore) Add(t *entity.Task) (int, error) {
+func (ts *TaskStore) Add(t *entity.Task) (entity.TaskID, error) {
 	ts.LastID++
 	t.ID = ts.LastID
 	ts.Tasks[t.ID] = t
 	return t.ID, nil
 }
 
-func (ts *TaskStore) Get(id int) (*entity.Task, error) {
+func (ts *TaskStore) Get(id entity.TaskID) (*entity.Task, error) {
 	if ts, ok := ts.Tasks[id]; ok {
 		return ts, nil
 	}

--- a/_chapter17/section70/entity/task.go
+++ b/_chapter17/section70/entity/task.go
@@ -3,12 +3,19 @@ package entity
 import "time"
 
 type TaskID int64
+type TaskStatus string
+
+const (
+	TaskStatusTodo  TaskStatus = "todo"
+	TaskStatusDoing TaskStatus = "doing"
+	TaskStatusDone  TaskStatus = "done"
+)
 
 type Task struct {
-	ID      TaskID    `json:"id"`
-	Title   string    `json:"title"`
-	Status  string    `json:"status" `
-	Created time.Time `json:"created"`
+	ID      TaskID     `json:"id"`
+	Title   string     `json:"title"`
+	Status  TaskStatus `json:"status" `
+	Created time.Time  `json:"created"`
 }
 
 type Tasks []*Task

--- a/_chapter17/section70/handler/list_task.go
+++ b/_chapter17/section70/handler/list_task.go
@@ -12,9 +12,9 @@ type ListTask struct {
 }
 
 type task struct {
-	ID     entity.TaskID `json:"id"`
-	Title  string        `json:"title"`
-	Status string        `json:"status"`
+	ID     entity.TaskID     `json:"id"`
+	Title  string            `json:"title"`
+	Status entity.TaskStatus `json:"status"`
 }
 
 func (lt *ListTask) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/errata.md
+++ b/errata.md
@@ -81,3 +81,22 @@ mux.Post("/register", ru.ServeHTTP)
 **P89 リスト9.1　無名関数は状態を持てる**
 `リスト9.1`ではなく、`リスト9.2`に修正。  
 [@YuyaAbo](https://github.com/YuyaAbo) さん[ご指摘](https://github.com/budougumi0617/go_todo_app/discussions/22) ありがとうございました。
+
+**P148 テストとコードカバレッジ取得の自動実行**
+「GitHub Actiuons上で実行したテスト結果」ではなく、「GitHub Actions上で実行したテスト結果」に修正。  
+[@kdnakt](https://twitter.com/kdnakt)さんご指摘ありがとうございました（2022/08/06）
+
+**P167 リスト17.3　「store/store.go」に実装したタスクの簡易管理方法**  
+`Tasks`変数は`&TaskStore{Tasks: map[int]*entity.Task{}}`ではなく、`&TaskStore{Tasks: map[entity.TaskID]*entity.Task{}}`に修正。  
+`TaskStore`構造体の`LastID`プロパティは`int`ではなく、`entity.TaskID`に修正。  
+`TaskStore`構造体の`Tasks`プロパティは`map[int]*entity.Task`ではなく、`map[entity.TaskID]*entity.Task`に修正。  
+`func (ts *TaskStore) Add(t *entity.Task) (int, error) {`ではなく、`func (ts *TaskStore) Add(t *entity.Task) (entity.TaskID, error) {`に修正。
+`func (ts *TaskStore) Get(id int) (*entity.Task, error) {`ではなく、`func (ts *TaskStore) Get(id entity.TaskID) (*entity.Task, error) {`
+[@mizutec](https://twitter.com/mizutec)さん[ご指摘](https://twitter.com/mizutec/status/1555043156865208320)ありがとうございました（2022/08/06）  
+[@Mo3g4u](https://github.com/Mo3g4u)さん[ご指摘](https://github.com/budougumi0617/go_todo_app/discussions/25)ありがとうございました（2022/08/06）
+
+**P173 リスト17.7　「handler/add_task.go」のタスクを追加する実装**
+`}{ID: id}` ではなく、`}{ID: int(id)}`に修正。
+
+**P175 リスト17.8　ファイルを使った入出力の検証**
+`Tasks: map[int]*entity.Task{},` ではなく、`Tasks: map[entity.TaskID]*entity.Task{},`に修正。

--- a/errata.md
+++ b/errata.md
@@ -96,7 +96,7 @@ mux.Post("/register", ru.ServeHTTP)
 [@Mo3g4u](https://github.com/Mo3g4u)さん[ご指摘](https://github.com/budougumi0617/go_todo_app/discussions/25)ありがとうございました（2022/08/06）
 
 **P173 リスト17.7　「handler/add_task.go」のタスクを追加する実装**
-`}{ID: id}` ではなく、`}{ID: int(id)}`に修正。
+`}{ID: id}` ではなく、`}{ID: int(id)}`に修正。（2022/08/06）
 
 **P175 リスト17.8　ファイルを使った入出力の検証**
-`Tasks: map[int]*entity.Task{},` ではなく、`Tasks: map[entity.TaskID]*entity.Task{},`に修正。
+`Tasks: map[int]*entity.Task{},` ではなく、`Tasks: map[entity.TaskID]*entity.Task{},`に修正。（2022/08/06）


### PR DESCRIPTION
- 正誤表を更新しました。
- GitHub上のCHAPTER17 Section68のサンプルコードが「P166 リスト17.1 「entity/task.go」に宣言したタスクの実装」で掲示した`type TaskStatus string`の定義・利用をしていなかったので反映しました。
  - [@___uhu](https://twitter.com/___uhu)さん[ご指摘](https://twitter.com/___uhu/status/1554459564556582912)ありがとうございました。