### PR TITLE
cleanup処理を正しく行う

### DIFF
--- a/_chapter18/section74/store/repository.go
+++ b/_chapter18/section74/store/repository.go
@@ -35,7 +35,7 @@ func New(ctx context.Context, cfg *config.Config) (*sqlx.DB, func(), error) {
 		),
 	)
 	if err != nil {
-		return nil, nil, err
+		return nil, func() {}, err
 	}
 	// Openは実際に接続テストが行われない。
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)

--- a/_chapter19/section75/main.go
+++ b/_chapter19/section75/main.go
@@ -29,10 +29,11 @@ func run(ctx context.Context) error {
 	url := fmt.Sprintf("http://%s", l.Addr().String())
 	log.Printf("start with: %v", url)
 	mux, cleanup, err := NewMux(ctx, cfg)
+	// エラーが返ってきてもcleanup関数は実行する
+	defer cleanup()
 	if err != nil {
 		return err
 	}
-	defer cleanup()
 	s := NewServer(l, mux)
 	return s.Run(ctx)
 }

--- a/_chapter19/section75/store/repository.go
+++ b/_chapter19/section75/store/repository.go
@@ -35,7 +35,7 @@ func New(ctx context.Context, cfg *config.Config) (*sqlx.DB, func(), error) {
 		),
 	)
 	if err != nil {
-		return nil, nil, err
+		return nil, func() {}, err
 	}
 	// Openは実際に接続テストが行われない。
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)

--- a/_chapter19/section78/main.go
+++ b/_chapter19/section78/main.go
@@ -29,10 +29,11 @@ func run(ctx context.Context) error {
 	url := fmt.Sprintf("http://%s", l.Addr().String())
 	log.Printf("start with: %v", url)
 	mux, cleanup, err := NewMux(ctx, cfg)
+	// エラーが返ってきてもcleanup関数は実行する
+	defer cleanup()
 	if err != nil {
 		return err
 	}
-	defer cleanup()
 	s := NewServer(l, mux)
 	return s.Run(ctx)
 }

--- a/_chapter19/section78/store/repository.go
+++ b/_chapter19/section78/store/repository.go
@@ -35,7 +35,7 @@ func New(ctx context.Context, cfg *config.Config) (*sqlx.DB, func(), error) {
 		),
 	)
 	if err != nil {
-		return nil, nil, err
+		return nil, func() {}, err
 	}
 	// Openは実際に接続テストが行われない。
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)

--- a/_chapter19/section79/main.go
+++ b/_chapter19/section79/main.go
@@ -29,10 +29,11 @@ func run(ctx context.Context) error {
 	url := fmt.Sprintf("http://%s", l.Addr().String())
 	log.Printf("start with: %v", url)
 	mux, cleanup, err := NewMux(ctx, cfg)
+	// エラーが返ってきてもcleanup関数は実行する
+	defer cleanup()
 	if err != nil {
 		return err
 	}
-	defer cleanup()
 	s := NewServer(l, mux)
 	return s.Run(ctx)
 }

--- a/_chapter19/section79/store/repository.go
+++ b/_chapter19/section79/store/repository.go
@@ -35,7 +35,7 @@ func New(ctx context.Context, cfg *config.Config) (*sqlx.DB, func(), error) {
 		),
 	)
 	if err != nil {
-		return nil, nil, err
+		return nil, func() {}, err
 	}
 	// Openは実際に接続テストが行われない。
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)

--- a/errata.md
+++ b/errata.md
@@ -176,7 +176,6 @@ https://github.com/golangci/golangci-lint/issues/3087 を参考に`brew install 
 [@mizutec](https://twitter.com/mizutec)さん[ご指摘](https://twitter.com/mizutec/status/1555043156865208320)ありがとうございました（2022/08/06）  
 [@Mo3g4u](https://github.com/Mo3g4u)さん[ご指摘](https://github.com/budougumi0617/go_todo_app/discussions/25)ありがとうございました（2022/08/06）
 
-
 **P172 SECTION-067タスクを登録するエンドポイントの実装**  
 「リクエストの処理が正常が完了する場合」ではなく、「リクエストの処理が正常に完了する場合」に修正。  
 [@y-magavel](https://github.com/y-magavel)さん[ご指摘](https://github.com/budougumi0617/go_todo_app/discussions/66) ありがとうございました（2022/10/02）
@@ -227,6 +226,37 @@ https://github.com/budougumi0617/go_todo_app/blob/v1.0.7/Makefile
 `fmt.Sprint`関数を使って`sql.Open`関数にわたす接続用文字列を生成していますが、MySQLとの接続では`go-sql-driver`の`Config.FormatDSN`メソッドを利用できます。  
 https://pkg.go.dev/github.com/go-sql-driver/mysql#Config.FormatDSN   
 [@nnabeyang](https://github.com/nnabeyang)さん[ご指摘](https://github.com/budougumi0617/go_todo_app/discussions/73) ありがとうございました（2022/12/12）
+
+**P192 リスト18.13 設定情報からDBへの接続を開く**  
+`sql.Open`関数の戻り値に対するエラーチェックで`return`する際の戻り値を「`nil, nil, err`」ではなく、「`nil, func() {}, err`」に修正。
+
+合わせてP204 リスト19.4の差分を
+```diff
+url := fmt.Sprintf("http://%s", l.Addr().String()) log.Printf("start with: %v", url)
+- mux := NewMux()
++ mux, cleanup, err := NewMux(ctx, cfg)
++ if err != nil {
++
++}
++ defer cleanup()
+s := NewServer(l, mux)
+```
+ではなく、
+```diff
+url := fmt.Sprintf("http://%s", l.Addr().String()) log.Printf("start with: %v", url)
+- mux := NewMux()
++ mux, cleanup, err := NewMux(ctx, cfg)
++ // エラーが返ってきてもcleanup関数は実行する
++ defer cleanup()
++ if err != nil {
++
++}
+s := NewServer(l, mux)
+```
+
+に修正。
+
+[@yamagit01](https://github.com/yamagit01)さん[ご指摘](https://github.com/budougumi0617/go_todo_app/discussions/81)ありがとうございました（2023/01/29）
 
 **P198 リスト18.19　「ListTasks」メソッドが期待されるデータを取得できるか検証**  
 「`t.Fatalf("unexected error: %v", err)`」ではなく、「`t.Fatalf("unexpected error: %v", err)`」に修正。  

--- a/errata.md
+++ b/errata.md
@@ -80,7 +80,7 @@ mux.Post("/register", ru.ServeHTTP)
 # 第2刷（2022年8月19日発行）
 **P48 COLUMN 「internal」パッケージ**  
 「たとえば、`example.com/root/internal`パッケージに`exported`な`Hooga`型が宣言されていた場合でも、」ではなく、
-「たとえば、`example.com/root/internal`パッケージに`exported`な`Hoge`型が宣言されていた場合でも、」に修正。
+「たとえば、`example.com/root/internal`パッケージに`exported`な`Hoge`型が宣言されていた場合でも、」に修正。  
 [@yakkun](https://github.com/yakkun)さん[ご指摘](https://github.com/budougumi0617/go_todo_app/discussions/80) ありがとうございました（2023/01/29）
 
 

--- a/errata.md
+++ b/errata.md
@@ -78,6 +78,12 @@ mux.Post("/register", ru.ServeHTTP)
 という装飾に修正。
 
 # 第2刷（2022年8月19日発行）
+**P48 COLUMN 「internal」パッケージ**  
+「たとえば、`example.com/root/internal`パッケージに`exported`な`Hooga`型が宣言されていた場合でも、」ではなく、
+「たとえば、`example.com/root/internal`パッケージに`exported`な`Hoge`型が宣言されていた場合でも、」に修正。
+[@yakkun](https://github.com/yakkun)さん[ご指摘](https://github.com/budougumi0617/go_todo_app/discussions/80) ありがとうございました（2023/01/29）
+
+
 **P77 リスト8.3　「errors.New」関数と「fmt.Errorf」関数**  
 「`return errors.New("GetAuthor: id is invalid")`」ではなく、「`return nil, errors.New("GetAuthor: id is invalid")`」に修正。  
 [@fuuukeee3](https://github.com/fuuukeee3) さん[ご指摘](https://github.com/budougumi0617/go_todo_app/discussions/42) ありがとうございました（2022/09/02）

--- a/main.go
+++ b/main.go
@@ -29,10 +29,11 @@ func run(ctx context.Context) error {
 	url := fmt.Sprintf("http://%s", l.Addr().String())
 	log.Printf("start with: %v", url)
 	mux, cleanup, err := NewMux(ctx, cfg)
+	// エラーが返ってきてもcleanup関数は実行する
+	defer cleanup()
 	if err != nil {
 		return err
 	}
-	defer cleanup()
 	s := NewServer(l, mux)
 	return s.Run(ctx)
 }

--- a/store/repository.go
+++ b/store/repository.go
@@ -35,7 +35,7 @@ func New(ctx context.Context, cfg *config.Config) (*sqlx.DB, func(), error) {
 		),
 	)
 	if err != nil {
-		return nil, nil, err
+		return nil, func() {}, err
 	}
 	// Openは実際に接続テストが行われない。
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)


### PR DESCRIPTION
- fix: P48コラム中の型名の表記ゆれを修正。
- fix: nilチェックせずにcleanup関数を実行できるように空関数を返す
- fix: cleanup実行漏れを塞いだ
- docs: 修正内容を正誤表に追記

関連discussions
- ref: https://github.com/budougumi0617/go_todo_app/discussions/80
- ref: https://github.com/budougumi0617/go_todo_app/discussions/81