### PR TITLE
update 'air' installation path, update golang version to 1.22

### DIFF
--- a/_chapter15/section59/Dockerfile
+++ b/_chapter15/section59/Dockerfile
@@ -1,5 +1,5 @@
 # デプロイ用コンテナに含めるバイナリを作成するコンテナ
-FROM golang:1.18.2-bullseye as deploy-builder
+FROM golang:1.22-bullseye as deploy-builder
 
 WORKDIR /app
 
@@ -21,7 +21,7 @@ CMD ["./app"]
 
 # ---------------------------------------------------
 
-FROM golang:1.18.2 as dev
+FROM golang:1.22 as dev
 WORKDIR /app
-RUN go install github.com/cosmtrek/air@latest
+RUN go install github.com/air-verse/air@latest
 CMD ["air"]


### PR DESCRIPTION
I'm a Korean reader. Thank you for the great book.

The path for the 'air' package has been updated to "github.com/air-verse/air".

As a result, an error occurs when using the existing Dockerfile.

It appears that the package can be composed without errors in Go 1.22 and later versions.