### PR TITLE
fix/errors in build and integration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         go-version: '>=1.18'
     - uses: actions/checkout@v3
     - run: |
-        go install github.com/k0kubun/sqldef/cmd/mysqldef@latest
+        go install github.com/sqldef/sqldef/cmd/mysqldef@latest
         mysqldef -u todo -p todo -h 127.0.0.1 -P 3306 todo < ./_tools/mysql/schema.sql
     - run: go test ./... -coverprofile=coverage.out
     - name: report coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ CMD ["./app"]
 
 # ---------------------------------------------------
 
-FROM golang:1.18.2 as dev
+FROM golang:1.22 as dev
 WORKDIR /app
-RUN go install github.com/cosmtrek/air@latest
+RUN go install github.com/air-verse/air@latest
 CMD ["air"]


### PR DESCRIPTION
# WHY
```
$ make build-local
docker compose build --no-cache
[+] Building 12.6s (6/6) FINISHED                                                                                                                                                           docker:rancher-desktop
 => [app internal] load .dockerignore                                                                                                                                                                         0.0s
 => => transferring context: 54B                                                                                                                                                                              0.0s
 => [app internal] load build definition from Dockerfile                                                                                                                                                      0.0s
 => => transferring dockerfile: 600B                                                                                                                                                                          0.0s
 => [app internal] load metadata for docker.io/library/golang:1.18.2                                                                                                                                          2.9s
 => [app dev 1/3] FROM docker.io/library/golang:1.18.2@sha256:04fab5aaf4fc18c40379924674491d988af3d9e97487472e674d0b5fd837dfac                                                                                0.0s
 => => resolve docker.io/library/golang:1.18.2@sha256:04fab5aaf4fc18c40379924674491d988af3d9e97487472e674d0b5fd837dfac                                                                                        0.0s
 => CACHED [app dev 2/3] WORKDIR /app                                                                                                                                                                         0.0s
 => ERROR [app dev 3/3] RUN go install github.com/air-verse/air@latest                                                                                                                                        9.6s
------
 > [app dev 3/3] RUN go install github.com/air-verse/air@latest:
4.710 go: downloading github.com/air-verse/air v1.52.3
4.840 go: downloading dario.cat/mergo v1.0.0
4.842 go: downloading github.com/creack/pty v1.1.21
4.874 go: downloading github.com/fatih/color v1.16.0
4.881 go: downloading github.com/fsnotify/fsnotify v1.7.0
4.901 go: downloading github.com/gohugoio/hugo v0.123.3
4.915 go: downloading github.com/pelletier/go-toml v1.9.5
5.259 go: downloading github.com/mattn/go-colorable v0.1.13
5.282 go: downloading github.com/mattn/go-isatty v0.0.20
5.294 go: downloading golang.org/x/sys v0.17.0
5.408 go: downloading github.com/bep/godartsass v1.2.0
5.433 go: downloading github.com/bep/godartsass/v2 v2.0.0
5.469 go: downloading github.com/bep/golibsass v1.1.1
5.507 go: downloading github.com/pelletier/go-toml/v2 v2.1.1
5.536 go: downloading github.com/spf13/afero v1.11.0
5.574 go: downloading github.com/tdewolff/parse/v2 v2.7.12
5.584 go: downloading github.com/cli/safeexec v1.0.1
5.612 go: downloading google.golang.org/protobuf v1.31.0
5.612 go: downloading golang.org/x/text v0.14.0
6.192 go: downloading github.com/spf13/cast v1.6.0
6.202 go: downloading github.com/mitchellh/hashstructure v1.1.0
6.220 go: downloading github.com/gobwas/glob v0.2.3
7.613 # github.com/gohugoio/hugo/common/types
7.613 /go/pkg/mod/github.com/gohugoio/hugo@v0.123.3/common/types/types.go:109:30: undefined: atomic.Int64
7.613 note: module requires Go 1.20
------
failed to solve: process "/bin/sh -c go install github.com/air-verse/air@latest" did not complete successfully: exit code: 2
make: *** [Makefile:10: build-local] Error 17

```

https://github.com/budougumi0617/go_todo_app/actions/runs/9915454960/job/27396324607
```
2s
Run go install github.com/k0kubun/sqldef/cmd/mysqldef@latest
go: downloading github.com/k0kubun/sqldef v0.[1](https://github.com/budougumi0617/go_todo_app/actions/runs/9915454960/job/27396324607#step:6:1)7.11
go: github.com/k0kubun/sqldef/cmd/mysqldef@latest: version constraints conflict:
	github.com/k0kubun/sqldef@v0.17.11: parsing go.mod:
	module declares its path as: github.com/sqldef/sqldef
	        but was required as: github.com/k0kubun/sqldef
Error: Process completed with exit code 1.
```
